### PR TITLE
Ensure Shift+Enter commits cell edits before moving

### DIFF
--- a/main.py
+++ b/main.py
@@ -289,9 +289,9 @@ class MainWindow(QtWidgets.QMainWindow):
         idx = self.view.currentIndex()
         if not idx.isValid():
             return
-        # Commit edit
-        self.view.closePersistentEditor(idx)
+        # Commit edit before closing so the text is saved
         self.view.commitData(editor_widget)
+        self.view.closePersistentEditor(idx)
         # Move down
         model = self.view.model()
         next_row = min(idx.row() + 1, model.rowCount() - 1) if model.rowCount() > 0 else 0

--- a/view.py
+++ b/view.py
@@ -114,9 +114,11 @@ class TableView(QtWidgets.QTableView):
         idx = self.currentIndex()
         if not idx.isValid():
             return
-        # Commit any open editor
+        # Commit any open editor before closing so data isn't lost
+        editor = self.focusWidget()
+        if editor:
+            self.commitData(editor)
         self.closePersistentEditor(idx)
-        self.commitData(self.focusWidget())
         model = self.model()
         if not model:
             return


### PR DESCRIPTION
## Summary
- Preserve cell edits when using Shift+Enter

## Testing
- `python -m py_compile main.py view.py model.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4bae2aa7c832f99a1927bac90e4f2